### PR TITLE
fix: Set REDIS_HOST to localhost in CI environments

### DIFF
--- a/.github/workflows/build_and_publish_release_please.yml.jinja
+++ b/.github/workflows/build_and_publish_release_please.yml.jinja
@@ -12,6 +12,7 @@ env:
   PIP_RETRIES: 5
 {% if include_postgres %}
   DATABASE_HOST: localhost
+  REDIS_HOST: localhost
 {% endif %}
   # required otherwise github api calls are rate limited
   GITHUB_TOKEN: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}

--- a/.github/workflows/build_and_publish_release_please_test_matrix.yml.jinja
+++ b/.github/workflows/build_and_publish_release_please_test_matrix.yml.jinja
@@ -15,6 +15,7 @@ env:
   PIP_RETRIES: 5
 {% if include_postgres %}
   DATABASE_HOST: localhost
+  REDIS_HOST: localhost
 {% endif %}
   # required otherwise github api calls are rate limited
   GITHUB_TOKEN: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}

--- a/.github/workflows/build_and_publish_test_matrix.yml.jinja
+++ b/.github/workflows/build_and_publish_test_matrix.yml.jinja
@@ -16,6 +16,7 @@ env:
   PIP_RETRIES: 5
 {% if include_postgres %}
   DATABASE_HOST: localhost
+  REDIS_HOST: localhost
 {% endif %}
   # required otherwise github api calls are rate limited
   GITHUB_TOKEN: ${{"{{"}} secrets.GITHUB_TOKEN {{"}}"}}


### PR DESCRIPTION
This PR adds `REDIS_HOST: localhost` to the GitHub Actions workflow templates alongside `DATABASE_HOST: localhost`.

Currently, if a project includes Postgres (which also provisions Redis in the compose file) but relies on `.envrc` falling back to `.orb.local` for the Redis host, the CI tests will fail because the OrbStack network is not available in GitHub Actions. This explicitly overrides it to `localhost` for CI.