### PR TITLE
feat(ci): enable mise bootstrap in github workflows

### DIFF
--- a/.github/workflows/build_and_publish_release_please.yml.jinja
+++ b/.github/workflows/build_and_publish_release_please.yml.jinja
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
       - run: uv build
       - run: uv publish
@@ -74,6 +77,9 @@ jobs:
       - uses: jdx/mise-action@v4
         env:
           MISE_ENV: ci
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
       - run: uv sync
       - run: just lint
@@ -87,6 +93,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - run: direnv allow . && direnv export gha >> "$GITHUB_ENV"{% if include_postgres %}
       - run: docker compose up -d --wait{% endif %}
       - run: uv sync

--- a/.github/workflows/build_and_publish_release_please_test_matrix.yml.jinja
+++ b/.github/workflows/build_and_publish_release_please_test_matrix.yml.jinja
@@ -26,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
       - run: uv sync
       - run: just lint
@@ -42,6 +45,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - run: mise use python@${{"{{"}} matrix.python-version {{"}}"}}{% if include_postgres %}
       - run: docker compose up -d --wait{% endif %}
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
@@ -84,6 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
       - run: uv sync
       - run: uv build

--- a/.github/workflows/build_and_publish_test_matrix.yml.jinja
+++ b/.github/workflows/build_and_publish_test_matrix.yml.jinja
@@ -28,6 +28,9 @@ jobs:
       - uses: jdx/mise-action@v4
         env:
           MISE_ENV: ci
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
       - run: uv sync
       - run: just lint
@@ -43,6 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - run: mise use python@${{"{{"}} matrix.python-version {{"}}"}}
       - uses: iloveitaly/github-action-direnv-load-and-mask@master{% if include_postgres %}
       - run: docker compose up -d --wait{% endif %}
@@ -65,6 +71,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+        with:
+          bootstrap: true
+          bootstrap_args: --update --yes
       - run: uv sync
 
       - name: Conventional Changelog Action

--- a/mise.toml
+++ b/mise.toml
@@ -5,5 +5,8 @@ uv = "latest"
 direnv = "latest"
 "github:casey/just" = "latest"
 
+[bootstrap.packages]
+"apt:zsh" = { os = "linux" }
+
 [settings]
 python.uv_venv_auto = "create|source"


### PR DESCRIPTION
## Summary
- Enable `mise bootstrap --update --yes` on every `jdx/mise-action` step in the Copier CI workflow templates.
- Install zsh via mise bootstrap on Linux so generated projects have the shell the template expects.

## Test plan
- [ ] Confirm each `jdx/mise-action@v4` step in the three `build_and_publish*.yml.jinja` templates includes `bootstrap: true` and `bootstrap_args: --update --yes`
- [ ] Confirm `mise.toml` includes `[bootstrap.packages]` with `apt:zsh` limited to Linux
- [ ] Generate a project from the template and verify CI installs zsh during mise bootstrap